### PR TITLE
Initial

### DIFF
--- a/lib/config_generator.py
+++ b/lib/config_generator.py
@@ -1,0 +1,106 @@
+import re
+import os
+from pathlib import Path
+
+ADDONS_DIR = os.path.abspath('../..')
+
+ACF_GUNS_PATHS = ADDONS_DIR + "/acf/lua/acf/shared/guns"
+STUBS_PATH = ADDONS_DIR + "/cfc_acf_stubber/lua/cfc_acf_stubber/stubs"
+
+PATTERN_DEFINE_GUN_CLASS = "ACF_defineGunClass\\(\"([\\w\\.]+)\", {\\s*\n([^\\)]+)} \\)"
+PATTERN_DEFINE_GUN = "ACF_defineGun\\(\"([\\w\\.]+)\", {\\s*\n([^\\)]+)} \\)"
+
+PATTERN_KEY_VALUES = "(?:\\s+([\\w]+)\\s?=\\s?(.+))|(})"
+
+PATTERN_COMMENT_BLOCK = "--\\[\\[[^\\]]+\\]\\](?:--)?"
+PATTERN_COMMENT_SINGLE = "--[^\n]+"
+
+LUA_HEADER = """AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+"""
+LUA_FOOTER = "}"
+
+def removeComments( commented ):
+	noBlockComments = ''.join( re.split( PATTERN_COMMENT_BLOCK, commented ) )
+	uncommented = ''.join( re.split( PATTERN_COMMENT_SINGLE, noBlockComments ) )
+	return uncommented
+
+def parseTable( keyValues ):
+	out = {}
+	tabs = [out]
+	for res in re.findall( PATTERN_KEY_VALUES, keyValues ):
+		curTab = tabs[-1]
+		if res[2] == "}":
+			del tabs[-1]
+			continue
+		key = res[0]
+		value = res[1].strip()
+		if value == "{":
+			curTab[key] = {}
+			tabs.append( curTab[key] )
+		else:
+			if value[-1] == ",":
+				value = value[:-1]
+			curTab[key] = value
+	return out
+
+def getClassNameAndData( raw ):
+	res = re.search( PATTERN_DEFINE_GUN_CLASS, raw )
+	gunClass = res.group(1)
+	keyValues = res.group(2)
+	data = parseTable( keyValues )
+	return gunClass, data
+
+def getGunNameAndData( raw ):
+	out = []
+	for res in re.findall( PATTERN_DEFINE_GUN, raw ):
+		gunName = res[0]
+		keyValues = res[1]
+		gunData = parseTable( keyValues )
+		out.append( [gunName, gunData] )
+	return out
+
+def dataToLua( data, indent = "" ):
+	out = ""
+	for key in data:
+		value = data[key]
+		out += indent + key + " = "
+		if type(value) is dict:
+			out += "{\n" + dataToLua( value, indent + "    " ) + indent + "},\n"
+		else:
+			out += value + ",\n"
+	return out
+
+def nameToFolder( name ):
+	name = name[1:-1]
+	name = name.replace( " ", "_" )
+	name = name.lower()
+	return name
+
+def main():
+	for filename in os.listdir( ACF_GUNS_PATHS ):
+		with open( ACF_GUNS_PATHS + "/" + filename ) as f:
+			data = f.read()
+		data = removeComments( data )
+		gunClass, classData = getClassNameAndData( data )
+		gunFolder = nameToFolder( classData["name"] or gunClass )
+
+		Path( STUBS_PATH + "/" + gunFolder ).mkdir( parents = True, exist_ok = True )
+
+		for obj in getGunNameAndData( data ):
+			gunName = obj[0]
+			gunDataAlone = obj[1]
+			gunData = {**classData, **gunDataAlone}
+
+			lua = LUA_HEADER + dataToLua( gunData, "    " ) + LUA_FOOTER
+			luaPath = Path( STUBS_PATH + "/" + gunFolder + "/" + gunName + ".lua" )
+			if luaPath.exists():
+				continue
+			with open( luaPath, "w" ) as f:
+				f.write( lua )
+
+if __name__ == "__main__":
+	main()
+	

--- a/lib/config_generator.py
+++ b/lib/config_generator.py
@@ -18,7 +18,7 @@ PATTERN_COMMENT_SINGLE = "--[^\n]+"
 LUA_HEADER = """AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
 """
 LUA_FOOTER = "}"
 
@@ -103,4 +103,3 @@ def main():
 
 if __name__ == "__main__":
 	main()
-	

--- a/lib/config_generator.py
+++ b/lib/config_generator.py
@@ -23,83 +23,83 @@ DATA = {
 LUA_FOOTER = "}"
 
 def remove_comments(commented):
-	noBlockComments = ''.join(re.split(PATTERN_COMMENT_BLOCK, commented))
-	uncommented = ''.join(re.split(PATTERN_COMMENT_SINGLE, noBlockComments))
-	return uncommented
+    noBlockComments = re.sub(PATTERN_COMMENT_BLOCK, '', commented)
+    uncommented = re.sub(PATTERN_COMMENT_SINGLE, '', noBlockComments)
+    return uncommented
 
 def parse_table(keyValues):
-	out = {}
-	tabs = [out]
-	for res in re.findall(PATTERN_KEY_VALUES, keyValues):
-		curTab = tabs[-1]
-		if res[2] == "}":
-			del tabs[-1]
-			continue
-		key = res[0]
-		value = res[1].strip()
-		if value == "{":
-			curTab[key] = {}
-			tabs.append(curTab[key])
-		else:
-			if value[-1] == ",":
-				value = value[:-1]
-			curTab[key] = value
-	return out
+    out = {}
+    tabs = [out]
+    for res in re.findall(PATTERN_KEY_VALUES, keyValues):
+        curTab = tabs[-1]
+        if res[2] == "}":
+            del tabs[-1]
+            continue
+        key = res[0]
+        value = res[1].strip()
+        if value == "{":
+            curTab[key] = {}
+            tabs.append(curTab[key])
+        else:
+            if value[-1] == ",":
+                value = value[:-1]
+            curTab[key] = value
+    return out
 
 def get_class_name_and_data(raw):
-	res = re.search(PATTERN_DEFINE_GUN_CLASS, raw)
-	gunClass = res.group(1)
-	keyValues = res.group(2)
-	data = parse_table(keyValues)
-	return gunClass, data
+    res = re.search(PATTERN_DEFINE_GUN_CLASS, raw)
+    gunClass = res.group(1)
+    keyValues = res.group(2)
+    data = parse_table(keyValues)
+    return gunClass, data
 
 def get_gun_name_and_data(raw):
-	out = []
-	for res in re.findall(PATTERN_DEFINE_GUN, raw):
-		gunName = res[0]
-		keyValues = res[1]
-		gunData = parse_table(keyValues)
-		out.append([gunName, gunData])
-	return out
+    out = []
+    for res in re.findall(PATTERN_DEFINE_GUN, raw):
+        gunName = res[0]
+        keyValues = res[1]
+        gunData = parse_table(keyValues)
+        out.append([gunName, gunData])
+    return out
 
 def data_to_lua(data, indent=""):
-	out = ""
-	for key in data:
-		value = data[key]
-		out += indent + key + " = "
-		if type(value) is dict:
-			out += "{\n" + data_to_lua(value, indent + "    ") + indent + "},\n"
-		else:
-			out += value + ",\n"
-	return out
+    out = ""
+    for key in data:
+        value = data[key]
+        out += indent + key + " = "
+        if type(value) is dict:
+            out += "{\n" + data_to_lua(value, indent + "    ") + indent + "},\n"
+        else:
+            out += value + ",\n"
+    return out
 
 def name_to_folder(name):
-	name = name[1:-1]
-	name = name.replace( " ", "_" )
-	name = name.lower()
-	return name
+    name = name[1:-1]
+    name = name.replace( " ", "_" )
+    name = name.lower()
+    return name
 
 def main():
-	for filename in os.listdir(ACF_GUNS_PATHS):
-		with open(ACF_GUNS_PATHS + "/" + filename) as f:
-			data = f.read()
-		data = remove_comments(data)
-		gunClass, classData = get_class_name_and_data( data )
-		gunFolder = name_to_folder(classData["name"] or gunClass)
+    for filename in os.listdir(ACF_GUNS_PATHS):
+        with open(ACF_GUNS_PATHS + "/" + filename) as f:
+            data = f.read()
+        data = remove_comments(data)
+        gunClass, classData = get_class_name_and_data( data )
+        gunFolder = name_to_folder(classData["name"] or gunClass)
 
-		Path(STUBS_PATH + "/" + gunFolder).mkdir(parents=True, exist_ok=True)
+        Path(STUBS_PATH + "/" + gunFolder).mkdir(parents=True, exist_ok=True)
 
-		for obj in get_gun_name_and_data(data):
-			gunName = obj[0]
-			gunDataAlone = obj[1]
-			gunData = {**classData, **gunDataAlone}
+        for obj in get_gun_name_and_data(data):
+            gunName = obj[0]
+            gunDataAlone = obj[1]
+            gunData = {**classData, **gunDataAlone}
 
-			lua = LUA_HEADER + data_to_lua(gunData, "    ") + LUA_FOOTER
-			luaPath = Path(STUBS_PATH + "/" + gunFolder + "/" + gunName + ".lua")
-			if luaPath.exists():
-				continue
-			with open(luaPath, "w") as f:
-				f.write(lua)
+            lua = LUA_HEADER + data_to_lua(gunData, "    ") + LUA_FOOTER
+            luaPath = Path(STUBS_PATH + "/" + gunFolder + "/" + gunName + ".lua")
+            if luaPath.exists():
+                continue
+            with open(luaPath, "w") as f:
+                f.write(lua)
 
 if __name__ == "__main__":
-	main()
+    main()

--- a/lib/config_generator.py
+++ b/lib/config_generator.py
@@ -23,43 +23,43 @@ DATA = {
 LUA_FOOTER = "}"
 
 def remove_comments(commented):
-    noBlockComments = re.sub(PATTERN_COMMENT_BLOCK, '', commented)
-    uncommented = re.sub(PATTERN_COMMENT_SINGLE, '', noBlockComments)
+    no_block_comments = re.sub(PATTERN_COMMENT_BLOCK, '', commented)
+    uncommented = re.sub(PATTERN_COMMENT_SINGLE, '', no_block_comments)
     return uncommented
 
-def parse_table(keyValues):
+def parse_table(key_values):
     out = {}
     tabs = [out]
-    for res in re.findall(PATTERN_KEY_VALUES, keyValues):
-        curTab = tabs[-1]
+    for res in re.findall(PATTERN_KEY_VALUES, key_values):
+        cur_tab = tabs[-1]
         if res[2] == "}":
             del tabs[-1]
             continue
         key = res[0]
         value = res[1].strip()
         if value == "{":
-            curTab[key] = {}
-            tabs.append(curTab[key])
+            cur_tab[key] = {}
+            tabs.append(cur_tab[key])
         else:
             if value[-1] == ",":
                 value = value[:-1]
-            curTab[key] = value
+            cur_tab[key] = value
     return out
 
 def get_class_name_and_data(raw):
     res = re.search(PATTERN_DEFINE_GUN_CLASS, raw)
-    gunClass = res.group(1)
-    keyValues = res.group(2)
-    data = parse_table(keyValues)
-    return gunClass, data
+    gun_class = res.group(1)
+    key_values = res.group(2)
+    data = parse_table(key_values)
+    return gun_class, data
 
 def get_gun_name_and_data(raw):
     out = []
     for res in re.findall(PATTERN_DEFINE_GUN, raw):
-        gunName = res[0]
-        keyValues = res[1]
-        gunData = parse_table(keyValues)
-        out.append([gunName, gunData])
+        gun_name = res[0]
+        key_values = res[1]
+        gun_data = parse_table(key_values)
+        out.append([gun_name, gun_data])
     return out
 
 def data_to_lua(data, indent=""):
@@ -84,21 +84,21 @@ def main():
         with open(ACF_GUNS_PATHS + "/" + filename) as f:
             data = f.read()
         data = remove_comments(data)
-        gunClass, classData = get_class_name_and_data( data )
-        gunFolder = name_to_folder(classData["name"] or gunClass)
+        gun_class, class_data = get_class_name_and_data( data )
+        gun_folder = name_to_folder(class_data["name"] or gun_class)
 
-        Path(STUBS_PATH + "/" + gunFolder).mkdir(parents=True, exist_ok=True)
+        Path(STUBS_PATH + "/" + gun_folder).mkdir(parents=True, exist_ok=True)
 
         for obj in get_gun_name_and_data(data):
-            gunName = obj[0]
-            gunDataAlone = obj[1]
-            gunData = {**classData, **gunDataAlone}
+            gun_name = obj[0]
+            gun_dataAlone = obj[1]
+            gun_data = {**class_data, **gun_dataAlone}
 
-            lua = LUA_HEADER + data_to_lua(gunData, "    ") + LUA_FOOTER
-            luaPath = Path(STUBS_PATH + "/" + gunFolder + "/" + gunName + ".lua")
-            if luaPath.exists():
+            lua = LUA_HEADER + data_to_lua(gun_data, "    ") + LUA_FOOTER
+            lua_path = Path(STUBS_PATH + "/" + gun_folder + "/" + gun_name + ".lua")
+            if lua_path.exists():
                 continue
-            with open(luaPath, "w") as f:
+            with open(lua_path, "w") as f:
                 f.write(lua)
 
 if __name__ == "__main__":

--- a/lua/autorun/cfc_acf_stubber_init.lua
+++ b/lua/autorun/cfc_acf_stubber_init.lua
@@ -1,0 +1,94 @@
+AddCSLuaFile()
+
+-- Load our stubs
+local PATH = "cfc_acf_stubber/stubs/"
+local stubData = {}
+
+-- In case "DATA" already exists, lets not cause a cancer bug
+local oldDATA = DATA
+local _, classes = file.Find( PATH .. "*", "LUA" )
+for _, class in pairs( classes ) do
+    local classPath = PATH .. class .. "/"
+    local stubs, _ = file.Find( classPath .. "*", "LUA" )
+    for _, stub in pairs( stubs ) do
+        include( classPath .. stub )
+        if not DATA.gunclass then
+            print(classPath .. stub)
+        end
+        local gunID = string.match( stub, "(.+)%.lua$" )
+        stubData[gunID] = DATA
+    end
+end
+DATA = oldDATA
+
+local function acfIsLoaded()
+    -- Acf uses gmod's "list" lib, puts the whole table of guns into it when finished loading them
+    return list.HasEntry( "ACFEnts", "Guns" )
+end
+
+-- only overwrite if not already the same, don't just always set at key. ACF likely uses mt, we want to avoid bringing stuff into the foretable if not needed
+local function sensitiveMerge( a, b )
+    for k, v in pairs( b ) do
+        if istable( a[k] ) and istable( v ) then
+            sensitiveMerge( a[k], v )
+        elseif a[k] ~= v then
+            a[k] = v
+        end
+    end
+end
+
+local function mapCase( tab )
+    local out = {}
+    for k, v in pairs( tab ) do
+        out[string.lower(v)] = v
+    end
+    return out
+end
+
+local function runStubs()
+    print( "[ACF Stubber] Running stubs!" )
+    local acfGuns = list.GetForEdit( "ACFEnts" ).Guns
+
+    local lowerToNormal = mapCase( table.GetKeys( acfGuns ) )
+    -- File name is converted to lower case when running AddCSLuaFile
+
+    for gunID, gunData in pairs( stubData ) do
+        gunID = lowerToNormal[gunID] or gunID
+        local gun = acfGuns[gunID]
+        if gun then
+            if gunData.enabled then
+                gunData.enabled = nil
+                sensitiveMerge( gun, gunData )
+            else
+                print("disable " .. gunID)
+                acfGuns[gunID] = nil
+            end
+        else
+            -- Could have already been removed this session
+            if gunData.enabled then
+                print( "[ACF Stubber] Found stub for gun that doesn't exist! - " .. gunID )
+            end
+        end
+    end
+end
+
+local function handleWaiterTimeout()
+    print( "[ACF Stubber] Waiter timed out! Not running stubs!" )
+end
+
+local waiterLoaded = Waiter
+
+if waiterLoaded then
+    print( "[ACF Stubber] Waiter is loaded, registering with it!" )
+    Waiter.waitFor( acfIsLoaded, runStubs, handleWaiterTimeout )
+else
+    print( "[ACF Stubber] Waiter is not loaded! Inserting our struct into the queue!" )
+    WaiterQueue = WaiterQueue or {}
+
+    local struct = {}
+    struct["waitingFor"] = acfIsLoaded
+    struct["onSuccess"] = runStubs
+    struct["onTimeout"] = handleWaiterTimeout
+
+    table.insert( WaiterQueue, struct )
+end

--- a/lua/autorun/cfc_acf_stubber_init.lua
+++ b/lua/autorun/cfc_acf_stubber_init.lua
@@ -12,9 +12,6 @@ for _, class in pairs( classes ) do
     local stubs, _ = file.Find( classPath .. "*", "LUA" )
     for _, stub in pairs( stubs ) do
         include( classPath .. stub )
-        if not DATA.gunclass then
-            print(classPath .. stub)
-        end
         local gunID = string.match( stub, "(.+)%.lua$" )
         stubData[gunID] = DATA
     end
@@ -60,7 +57,6 @@ local function runStubs()
                 gunData.enabled = nil
                 sensitiveMerge( gun, gunData )
             else
-                print("disable " .. gunID)
                 acfGuns[gunID] = nil
             end
         else

--- a/lua/cfc_acf_stubber/stubs/autocannon/20mmAC.lua
+++ b/lua/cfc_acf_stubber/stubs/autocannon/20mmAC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.12,
     name = "20mm Autocannon",
     desc = "The 20mm AC is the smallest of the family; having a good rate of fire but a tiny shell.",

--- a/lua/cfc_acf_stubber/stubs/autocannon/20mmAC.lua
+++ b/lua/cfc_acf_stubber/stubs/autocannon/20mmAC.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.12,
+    name = "20mm Autocannon",
+    desc = "The 20mm AC is the smallest of the family; having a good rate of fire but a tiny shell.",
+    muzzleflash = "30mm_muzzleflash_noscale",
+    rofmod = 0.7,
+    sound = "weapons/ACF_Gun/ac_fire4.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    model = "models/autocannon/autocannon_20mm.mdl",
+    caliber = 2.0,
+    gunclass = "AC",
+    weight = 225,
+    year = 1930,
+    magsize = 100,
+    magreload = 3,
+    round = {
+        maxlength = 32,
+        propweight = 0.13,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/autocannon/30mmAC.lua
+++ b/lua/cfc_acf_stubber/stubs/autocannon/30mmAC.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.12,
+    name = "30mm Autocannon",
+    desc = "The 30mm AC can fire shells with sufficient space for a small payload, and has modest anti-armor capability",
+    muzzleflash = "30mm_muzzleflash_noscale",
+    rofmod = 0.5,
+    sound = "weapons/ACF_Gun/ac_fire4.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    model = "models/autocannon/autocannon_30mm.mdl",
+    gunclass = "AC",
+    caliber = 3.0,
+    weight = 960,
+    year = 1935,
+    magsize = 75,
+    magreload = 3,
+    round = {
+        maxlength = 39,
+        propweight = 0.350,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/autocannon/30mmAC.lua
+++ b/lua/cfc_acf_stubber/stubs/autocannon/30mmAC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.12,
     name = "30mm Autocannon",
     desc = "The 30mm AC can fire shells with sufficient space for a small payload, and has modest anti-armor capability",

--- a/lua/cfc_acf_stubber/stubs/autocannon/40mmAC.lua
+++ b/lua/cfc_acf_stubber/stubs/autocannon/40mmAC.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.12,
+    name = "40mm Autocannon",
+    desc = "The 40mm AC can fire shells with sufficient space for a useful payload, and can get decent penetration with proper rounds.",
+    muzzleflash = "30mm_muzzleflash_noscale",
+    rofmod = 0.48,
+    sound = "weapons/ACF_Gun/ac_fire4.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    model = "models/autocannon/autocannon_40mm.mdl",
+    gunclass = "AC",
+    caliber = 4.0,
+    weight = 1500,
+    year = 1940,
+    magsize = 30,
+    magreload = 3,
+    round = {
+        maxlength = 45,
+        propweight = 0.9,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/autocannon/40mmAC.lua
+++ b/lua/cfc_acf_stubber/stubs/autocannon/40mmAC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.12,
     name = "40mm Autocannon",
     desc = "The 40mm AC can fire shells with sufficient space for a useful payload, and can get decent penetration with proper rounds.",

--- a/lua/cfc_acf_stubber/stubs/autocannon/50mmAC.lua
+++ b/lua/cfc_acf_stubber/stubs/autocannon/50mmAC.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.12,
+    name = "50mm Autocannon",
+    desc = "The 50mm AC fires shells comparable with the 50mm Cannon, making it capable of destroying light armour quite quickly.",
+    muzzleflash = "30mm_muzzleflash_noscale",
+    rofmod = 0.4,
+    sound = "weapons/ACF_Gun/ac_fire4.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    model = "models/autocannon/autocannon_50mm.mdl",
+    gunclass = "AC",
+    caliber = 5.0,
+    weight = 2130,
+    year = 1965,
+    magsize = 20,
+    magreload = 3,
+    round = {
+        maxlength = 52,
+        propweight = 1.2,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/autocannon/50mmAC.lua
+++ b/lua/cfc_acf_stubber/stubs/autocannon/50mmAC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.12,
     name = "50mm Autocannon",
     desc = "The 50mm AC fires shells comparable with the 50mm Cannon, making it capable of destroying light armour quite quickly.",

--- a/lua/cfc_acf_stubber/stubs/autoloader/100mmAL.lua
+++ b/lua/cfc_acf_stubber/stubs/autoloader/100mmAL.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.08,
+    name = "100mm Autoloading Cannon",
+    desc = "The 100mm is good for rapidly hitting medium armor, then running like your ass is on fire to reload.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 0.85,
+    sound = "weapons/ACF_Gun/autoloader.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_al_100mm.mdl",
+    gunclass = "AL",
+    caliber = 10.0,
+    weight = 3325,
+    year = 1956,
+    magsize = 6,
+    magreload = 21,
+    round = {
+        maxlength = 93,
+        propweight = 9.5,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/autoloader/100mmAL.lua
+++ b/lua/cfc_acf_stubber/stubs/autoloader/100mmAL.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.08,
     name = "100mm Autoloading Cannon",
     desc = "The 100mm is good for rapidly hitting medium armor, then running like your ass is on fire to reload.",

--- a/lua/cfc_acf_stubber/stubs/autoloader/120mmAL.lua
+++ b/lua/cfc_acf_stubber/stubs/autoloader/120mmAL.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.08,
+    name = "120mm Autoloading Cannon",
+    desc = "The 120mm autoloader can do serious damage before reloading, but the reload time is killer.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 0.757,
+    sound = "weapons/ACF_Gun/autoloader.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_al_120mm.mdl",
+    gunclass = "AL",
+    caliber = 12.0,
+    weight = 6050,
+    year = 1956,
+    magsize = 5,
+    magreload = 27,
+    round = {
+        maxlength = 110,
+        propweight = 18,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/autoloader/120mmAL.lua
+++ b/lua/cfc_acf_stubber/stubs/autoloader/120mmAL.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.08,
     name = "120mm Autoloading Cannon",
     desc = "The 120mm autoloader can do serious damage before reloading, but the reload time is killer.",

--- a/lua/cfc_acf_stubber/stubs/autoloader/140mmAL.lua
+++ b/lua/cfc_acf_stubber/stubs/autoloader/140mmAL.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = false,
+    enabled = false,
     spread = 0.08,
     name = "140mm Autoloading Cannon",
     desc = "The 140mm can shred a medium tank's armor with one magazine, and even function as shoot & scoot artillery, with its useful HE payload.",

--- a/lua/cfc_acf_stubber/stubs/autoloader/140mmAL.lua
+++ b/lua/cfc_acf_stubber/stubs/autoloader/140mmAL.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = false,
+    spread = 0.08,
+    name = "140mm Autoloading Cannon",
+    desc = "The 140mm can shred a medium tank's armor with one magazine, and even function as shoot & scoot artillery, with its useful HE payload.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 0.743,
+    sound = "weapons/ACF_Gun/autoloader.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_al_140mm.mdl",
+    gunclass = "AL",
+    caliber = 14.0,
+    weight = 8830,
+    year = 1970,
+    magsize = 5,
+    magreload = 35,
+    round = {
+        maxlength = 127,
+        propweight = 28,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/autoloader/75mmAL.lua
+++ b/lua/cfc_acf_stubber/stubs/autoloader/75mmAL.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.08,
     name = "75mm Autoloading Cannon",
     desc = "A quick-firing 75mm gun, pops off a number of rounds in relatively short order.",

--- a/lua/cfc_acf_stubber/stubs/autoloader/75mmAL.lua
+++ b/lua/cfc_acf_stubber/stubs/autoloader/75mmAL.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.08,
+    name = "75mm Autoloading Cannon",
+    desc = "A quick-firing 75mm gun, pops off a number of rounds in relatively short order.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1,
+    sound = "weapons/ACF_Gun/autoloader.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_al_75mm.mdl",
+    gunclass = "AL",
+    caliber = 7.5,
+    weight = 1892,
+    year = 1946,
+    magsize = 8,
+    magreload = 15,
+    round = {
+        maxlength = 78,
+        propweight = 3.8,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/cannon/100mmC.lua
+++ b/lua/cfc_acf_stubber/stubs/cannon/100mmC.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.08,
+    name = "100mm Cannon",
+    desc = "The 100mm was a benchmark for the early cold war period, and has great muzzle velocity and hitting power, while still boasting a respectable, if small, payload.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 2,
+    sound = "weapons/ACF_Gun/cannon_new.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_100mm.mdl",
+    gunclass = "C",
+    caliber = 10.0,
+    weight = 2750,
+    year = 1944,
+    round = {
+        maxlength = 93,
+        propweight = 9.5,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/cannon/100mmC.lua
+++ b/lua/cfc_acf_stubber/stubs/cannon/100mmC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.08,
     name = "100mm Cannon",
     desc = "The 100mm was a benchmark for the early cold war period, and has great muzzle velocity and hitting power, while still boasting a respectable, if small, payload.",

--- a/lua/cfc_acf_stubber/stubs/cannon/120mmC.lua
+++ b/lua/cfc_acf_stubber/stubs/cannon/120mmC.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.08,
+    name = "120mm Cannon",
+    desc = "Often found in MBTs, the 120mm shreds lighter armor with utter impunity, and is formidable against even the big boys.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 2,
+    sound = "weapons/ACF_Gun/cannon_new.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_120mm.mdl",
+    gunclass = "C",
+    caliber = 12.0,
+    weight = 5200,
+    year = 1955,
+    round = {
+        maxlength = 110,
+        propweight = 18,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/cannon/120mmC.lua
+++ b/lua/cfc_acf_stubber/stubs/cannon/120mmC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.08,
     name = "120mm Cannon",
     desc = "Often found in MBTs, the 120mm shreds lighter armor with utter impunity, and is formidable against even the big boys.",

--- a/lua/cfc_acf_stubber/stubs/cannon/140mmC.lua
+++ b/lua/cfc_acf_stubber/stubs/cannon/140mmC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = false,
+    enabled = false,
     spread = 0.08,
     name = "140mm Cannon",
     desc = "The 140mm fires a massive shell with enormous penetrative capability, but has a glacial reload speed and a very hefty weight.",

--- a/lua/cfc_acf_stubber/stubs/cannon/140mmC.lua
+++ b/lua/cfc_acf_stubber/stubs/cannon/140mmC.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = false,
+    spread = 0.08,
+    name = "140mm Cannon",
+    desc = "The 140mm fires a massive shell with enormous penetrative capability, but has a glacial reload speed and a very hefty weight.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 2,
+    sound = "weapons/ACF_Gun/cannon_new.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_140mm.mdl",
+    gunclass = "C",
+    caliber = 14.0,
+    weight = 8180,
+    year = 1990,
+    round = {
+        maxlength = 127,
+        propweight = 28,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/cannon/37mmC.lua
+++ b/lua/cfc_acf_stubber/stubs/cannon/37mmC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.08,
     name = "37mm Cannon",
     desc = "A light and fairly weak cannon with good accuracy.",

--- a/lua/cfc_acf_stubber/stubs/cannon/37mmC.lua
+++ b/lua/cfc_acf_stubber/stubs/cannon/37mmC.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.08,
+    name = "37mm Cannon",
+    desc = "A light and fairly weak cannon with good accuracy.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.4,
+    sound = "weapons/ACF_Gun/ac_fire4.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_37mm.mdl",
+    gunclass = "C",
+    caliber = 3.7,
+    weight = 350,
+    year = 1919,
+    round = {
+        maxlength = 48,
+        propweight = 1.125,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/cannon/50mmC.lua
+++ b/lua/cfc_acf_stubber/stubs/cannon/50mmC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.08,
     name = "50mm Cannon",
     desc = "The 50mm is surprisingly fast-firing, with good effectiveness against light armor, but a pea-shooter compared to its bigger cousins",

--- a/lua/cfc_acf_stubber/stubs/cannon/50mmC.lua
+++ b/lua/cfc_acf_stubber/stubs/cannon/50mmC.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.08,
+    name = "50mm Cannon",
+    desc = "The 50mm is surprisingly fast-firing, with good effectiveness against light armor, but a pea-shooter compared to its bigger cousins",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 2,
+    sound = "weapons/ACF_Gun/ac_fire4.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_50mm.mdl",
+    gunclass = "C",
+    caliber = 5.0,
+    weight = 665,
+    year = 1935,
+    round = {
+        maxlength = 63,
+        propweight = 2.1,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/cannon/75mmC.lua
+++ b/lua/cfc_acf_stubber/stubs/cannon/75mmC.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.08,
+    name = "75mm Cannon",
+    desc = "The 75mm is still rather respectable in rate of fire, but has only modest payload.  Often found on the Eastern Front, and on cold war light tanks.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 2,
+    sound = "weapons/ACF_Gun/cannon_new.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_75mm.mdl",
+    gunclass = "C",
+    caliber = 7.5,
+    weight = 1420,
+    year = 1942,
+    round = {
+        maxlength = 78,
+        propweight = 3.8,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/cannon/75mmC.lua
+++ b/lua/cfc_acf_stubber/stubs/cannon/75mmC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.08,
     name = "75mm Cannon",
     desc = "The 75mm is still rather respectable in rate of fire, but has only modest payload.  Often found on the Eastern Front, and on cold war light tanks.",

--- a/lua/cfc_acf_stubber/stubs/grenade_launcher/40mmGL.lua
+++ b/lua/cfc_acf_stubber/stubs/grenade_launcher/40mmGL.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.32,
+    name = "40mm Grenade Launcher",
+    desc = "The 40mm chews up infantry but is about as useful as tits on a nun for fighting armor.  Often found on 4x4s rolling through the third world.",
+    muzzleflash = "40mm_muzzleflash_noscale",
+    rofmod = 1,
+    sound = "weapons/acf_gun/grenadelauncher.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    model = "models/launcher/40mmgl.mdl",
+    gunclass = "GL",
+    caliber = 4.0,
+    weight = 55,
+    magsize = 6,
+    magreload = 7.5,
+    year = 1970,
+    round = {
+        maxlength = 7.5,
+        propweight = 0.01,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/grenade_launcher/40mmGL.lua
+++ b/lua/cfc_acf_stubber/stubs/grenade_launcher/40mmGL.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.32,
     name = "40mm Grenade Launcher",
     desc = "The 40mm chews up infantry but is about as useful as tits on a nun for fighting armor.  Often found on 4x4s rolling through the third world.",

--- a/lua/cfc_acf_stubber/stubs/heavy_machinegun/13mmHMG.lua
+++ b/lua/cfc_acf_stubber/stubs/heavy_machinegun/13mmHMG.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.4,
     name = "13mm Heavy Machinegun",
     desc = "The lightest of the HMGs, the 13mm has a rapid fire rate but suffers from poor payload size.  Often used to strafe ground troops or annoy low-flying aircraft.",

--- a/lua/cfc_acf_stubber/stubs/heavy_machinegun/13mmHMG.lua
+++ b/lua/cfc_acf_stubber/stubs/heavy_machinegun/13mmHMG.lua
@@ -1,0 +1,29 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.4,
+    name = "13mm Heavy Machinegun",
+    desc = "The lightest of the HMGs, the 13mm has a rapid fire rate but suffers from poor payload size.  Often used to strafe ground troops or annoy low-flying aircraft.",
+    muzzleflash = "50cal_muzzleflash_noscale",
+    rofmod = 3.3,
+    sound = "weapons/ACF_Gun/mg_fire3.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    longbarrel = {
+        index = 2,
+        submodel = 4,
+        newpos = "muzzle2",
+    },
+    model = "models/machinegun/machinegun_20mm.mdl",
+    gunclass = "HMG",
+    caliber = 1.3,
+    weight = 90,
+    year = 1935,
+    magsize = 35,
+    magreload = 6,
+    round = {
+        maxlength = 22,
+        propweight = 0.09,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/heavy_machinegun/20mmHMG.lua
+++ b/lua/cfc_acf_stubber/stubs/heavy_machinegun/20mmHMG.lua
@@ -1,0 +1,29 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.4,
+    name = "20mm Heavy Machinegun",
+    desc = "The 20mm has a rapid fire rate but suffers from poor payload size.  Often used to strafe ground troops or annoy low-flying aircraft.",
+    muzzleflash = "50cal_muzzleflash_noscale",
+    rofmod = 1.9,
+    sound = "weapons/ACF_Gun/mg_fire3.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    longbarrel = {
+        index = 2,
+        submodel = 4,
+        newpos = "muzzle2",
+    },
+    model = "models/machinegun/machinegun_20mm_compact.mdl",
+    gunclass = "HMG",
+    caliber = 2.0,
+    weight = 160,
+    year = 1935,
+    magsize = 30,
+    magreload = 6,
+    round = {
+        maxlength = 30,
+        propweight = 0.12,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/heavy_machinegun/20mmHMG.lua
+++ b/lua/cfc_acf_stubber/stubs/heavy_machinegun/20mmHMG.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.4,
     name = "20mm Heavy Machinegun",
     desc = "The 20mm has a rapid fire rate but suffers from poor payload size.  Often used to strafe ground troops or annoy low-flying aircraft.",

--- a/lua/cfc_acf_stubber/stubs/heavy_machinegun/30mmHMG.lua
+++ b/lua/cfc_acf_stubber/stubs/heavy_machinegun/30mmHMG.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.4,
     name = "30mm Heavy Machinegun",
     desc = "30mm shell chucker, light and compact. Your average cold war dogfight go-to.",

--- a/lua/cfc_acf_stubber/stubs/heavy_machinegun/30mmHMG.lua
+++ b/lua/cfc_acf_stubber/stubs/heavy_machinegun/30mmHMG.lua
@@ -1,0 +1,29 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.4,
+    name = "30mm Heavy Machinegun",
+    desc = "30mm shell chucker, light and compact. Your average cold war dogfight go-to.",
+    muzzleflash = "50cal_muzzleflash_noscale",
+    rofmod = 1.1,
+    sound = "weapons/ACF_Gun/mg_fire3.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    longbarrel = {
+        index = 2,
+        submodel = 4,
+        newpos = "muzzle2",
+    },
+    model = "models/machinegun/machinegun_30mm_compact.mdl",
+    gunclass = "HMG",
+    caliber = 3.0,
+    weight = 480,
+    year = 1941,
+    magsize = 25,
+    magreload = 6,
+    round = {
+        maxlength = 37,
+        propweight = 0.35,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/heavy_machinegun/40mmHMG.lua
+++ b/lua/cfc_acf_stubber/stubs/heavy_machinegun/40mmHMG.lua
@@ -1,0 +1,29 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.4,
+    name = "40mm Heavy Machinegun",
+    desc = "The heaviest of the heavy machineguns.  Massively powerful with a killer reload and hefty ammunition requirements, it can pop even relatively heavy targets with ease.",
+    muzzleflash = "50cal_muzzleflash_noscale",
+    rofmod = 0.95,
+    sound = "weapons/ACF_Gun/mg_fire3.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    longbarrel = {
+        index = 2,
+        submodel = 4,
+        newpos = "muzzle2",
+    },
+    model = "models/machinegun/machinegun_40mm_compact.mdl",
+    gunclass = "HMG",
+    caliber = 4.0,
+    weight = 780,
+    year = 1955,
+    magsize = 20,
+    magreload = 8,
+    round = {
+        maxlength = 42,
+        propweight = 0.9,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/heavy_machinegun/40mmHMG.lua
+++ b/lua/cfc_acf_stubber/stubs/heavy_machinegun/40mmHMG.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.4,
     name = "40mm Heavy Machinegun",
     desc = "The heaviest of the heavy machineguns.  Massively powerful with a killer reload and hefty ammunition requirements, it can pop even relatively heavy targets with ease.",

--- a/lua/cfc_acf_stubber/stubs/howitzer/105mmHW.lua
+++ b/lua/cfc_acf_stubber/stubs/howitzer/105mmHW.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.12,
     name = "105mm Howitzer",
     desc = "The 105 lobs a big shell far, and its HEAT rounds can be extremely effective against even heavier armor.",

--- a/lua/cfc_acf_stubber/stubs/howitzer/105mmHW.lua
+++ b/lua/cfc_acf_stubber/stubs/howitzer/105mmHW.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.12,
+    name = "105mm Howitzer",
+    desc = "The 105 lobs a big shell far, and its HEAT rounds can be extremely effective against even heavier armor.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.8,
+    sound = "weapons/ACF_Gun/howitzer_new2.wav",
+    soundDistance = "Howitzer.Fire",
+    soundNormal = " ",
+    model = "models/howitzer/howitzer_105mm.mdl",
+    gunclass = "HW",
+    caliber = 10.5,
+    weight = 1480,
+    year = 1900,
+    round = {
+        maxlength = 86,
+        propweight = 3.75,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/howitzer/122mmHW.lua
+++ b/lua/cfc_acf_stubber/stubs/howitzer/122mmHW.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.12,
+    name = "122mm Howitzer",
+    desc = "The 122mm bridges the gap between the 105 and the 155, providing a lethal round with a big splash radius.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.8,
+    sound = "weapons/ACF_Gun/howitzer_new2.wav",
+    soundDistance = "Howitzer.Fire",
+    soundNormal = " ",
+    model = "models/howitzer/howitzer_122mm.mdl",
+    gunclass = "HW",
+    caliber = 12.2,
+    weight = 3420,
+    year = 1900,
+    round = {
+        maxlength = 106,
+        propweight = 7,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/howitzer/122mmHW.lua
+++ b/lua/cfc_acf_stubber/stubs/howitzer/122mmHW.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.12,
     name = "122mm Howitzer",
     desc = "The 122mm bridges the gap between the 105 and the 155, providing a lethal round with a big splash radius.",

--- a/lua/cfc_acf_stubber/stubs/howitzer/155mmHW.lua
+++ b/lua/cfc_acf_stubber/stubs/howitzer/155mmHW.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.12,
     name = "155mm Howitzer",
     desc = "The 155 is a classic heavy artillery round, with good reason.  A versatile weapon, it's found on most modern SPGs.",

--- a/lua/cfc_acf_stubber/stubs/howitzer/155mmHW.lua
+++ b/lua/cfc_acf_stubber/stubs/howitzer/155mmHW.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.12,
+    name = "155mm Howitzer",
+    desc = "The 155 is a classic heavy artillery round, with good reason.  A versatile weapon, it's found on most modern SPGs.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.8,
+    sound = "weapons/ACF_Gun/howitzer_new2.wav",
+    soundDistance = "Howitzer.Fire",
+    soundNormal = " ",
+    model = "models/howitzer/howitzer_155mm.mdl",
+    gunclass = "HW",
+    caliber = 15.5,
+    weight = 5340,
+    year = 1900,
+    round = {
+        maxlength = 124,
+        propweight = 13.5,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/howitzer/155mmHW.lua
+++ b/lua/cfc_acf_stubber/stubs/howitzer/155mmHW.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-    enabled = true,
+    enabled = false,
     spread = 0.12,
     name = "155mm Howitzer",
     desc = "The 155 is a classic heavy artillery round, with good reason.  A versatile weapon, it's found on most modern SPGs.",

--- a/lua/cfc_acf_stubber/stubs/howitzer/203mmHW.lua
+++ b/lua/cfc_acf_stubber/stubs/howitzer/203mmHW.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = false,
+    enabled = false,
     spread = 0.12,
     name = "203mm Howitzer",
     desc = "An 8-inch deck gun, found on siege artillery and cruisers.",

--- a/lua/cfc_acf_stubber/stubs/howitzer/203mmHW.lua
+++ b/lua/cfc_acf_stubber/stubs/howitzer/203mmHW.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = false,
+    spread = 0.12,
+    name = "203mm Howitzer",
+    desc = "An 8-inch deck gun, found on siege artillery and cruisers.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.8,
+    sound = "weapons/ACF_Gun/howitzer_new2.wav",
+    soundDistance = "Howitzer.Fire",
+    soundNormal = " ",
+    model = "models/howitzer/howitzer_203mm.mdl",
+    gunclass = "HW",
+    caliber = 20.3,
+    weight = 10280,
+    year = 1900,
+    round = {
+        maxlength = 162.4,
+        propweight = 28.5,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/howitzer/75mmHW.lua
+++ b/lua/cfc_acf_stubber/stubs/howitzer/75mmHW.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.12,
+    name = "75mm Howitzer",
+    desc = "Often found being towed by large smelly animals, the 75mm has a high rate of fire, and is surprisingly lethal against light armor.  Great for a sustained barrage against someone you really don't like.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.8,
+    sound = "weapons/ACF_Gun/howitzer_new2.wav",
+    soundDistance = "Howitzer.Fire",
+    soundNormal = " ",
+    model = "models/howitzer/howitzer_75mm.mdl",
+    gunclass = "HW",
+    caliber = 7.5,
+    weight = 530,
+    year = 1900,
+    round = {
+        maxlength = 60,
+        propweight = 1.8,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/howitzer/75mmHW.lua
+++ b/lua/cfc_acf_stubber/stubs/howitzer/75mmHW.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.12,
     name = "75mm Howitzer",
     desc = "Often found being towed by large smelly animals, the 75mm has a high rate of fire, and is surprisingly lethal against light armor.  Great for a sustained barrage against someone you really don't like.",

--- a/lua/cfc_acf_stubber/stubs/machinegun/12.7mmMG.lua
+++ b/lua/cfc_acf_stubber/stubs/machinegun/12.7mmMG.lua
@@ -1,0 +1,25 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.24,
+    name = "12.7mm Machinegun",
+    desc = "The 12.7mm MG is still light, finding its way into a lot of mountings, including on top of tanks.",
+    muzzleflash = "50cal_muzzleflash_noscale",
+    rofmod = 1,
+    sound = "weapons/ACF_Gun/mg_fire4.wav",
+    soundNormal = "weapons/ACF_Gun/mg_fire4.wav",
+    soundDistance = "",
+    model = "models/machinegun/machinegun_127mm.mdl",
+    gunclass = "MG",
+    canparent = true,
+    caliber = 1.27,
+    weight = 30,
+    year = 1910,
+    magsize = 150,
+    magreload = 6,
+    round = {
+        maxlength = 15.8,
+        propweight = 0.03,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/machinegun/12.7mmMG.lua
+++ b/lua/cfc_acf_stubber/stubs/machinegun/12.7mmMG.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.24,
     name = "12.7mm Machinegun",
     desc = "The 12.7mm MG is still light, finding its way into a lot of mountings, including on top of tanks.",

--- a/lua/cfc_acf_stubber/stubs/machinegun/14.5mmMG.lua
+++ b/lua/cfc_acf_stubber/stubs/machinegun/14.5mmMG.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.24,
     name = "14.5mm Machinegun",
     desc = "The 14.5mm MG trades its smaller stablemates' rate of fire for more armor penetration and damage.",

--- a/lua/cfc_acf_stubber/stubs/machinegun/14.5mmMG.lua
+++ b/lua/cfc_acf_stubber/stubs/machinegun/14.5mmMG.lua
@@ -1,0 +1,25 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.24,
+    name = "14.5mm Machinegun",
+    desc = "The 14.5mm MG trades its smaller stablemates' rate of fire for more armor penetration and damage.",
+    muzzleflash = "50cal_muzzleflash_noscale",
+    rofmod = 1,
+    sound = "weapons/ACF_Gun/mg_fire4.wav",
+    soundNormal = "weapons/ACF_Gun/mg_fire4.wav",
+    soundDistance = "",
+    model = "models/machinegun/machinegun_145mm.mdl",
+    gunclass = "MG",
+    canparent = true,
+    caliber = 1.45,
+    weight = 45,
+    year = 1932,
+    magsize = 90,
+    magreload = 5,
+    round = {
+        maxlength = 19.5,
+        propweight = 0.04,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/machinegun/7.62mmMG.lua
+++ b/lua/cfc_acf_stubber/stubs/machinegun/7.62mmMG.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.24,
     name = "7.62mm Machinegun",
     desc = "The 7.62mm is effective against infantry, but its usefulness against armor is laughable at best.",

--- a/lua/cfc_acf_stubber/stubs/machinegun/7.62mmMG.lua
+++ b/lua/cfc_acf_stubber/stubs/machinegun/7.62mmMG.lua
@@ -1,0 +1,25 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.24,
+    name = "7.62mm Machinegun",
+    desc = "The 7.62mm is effective against infantry, but its usefulness against armor is laughable at best.",
+    muzzleflash = "50cal_muzzleflash_noscale",
+    rofmod = 1.59,
+    sound = "weapons/ACF_Gun/mg_fire4.wav",
+    soundNormal = "weapons/ACF_Gun/mg_fire4.wav",
+    soundDistance = "",
+    model = "models/machinegun/machinegun_762mm.mdl",
+    gunclass = "MG",
+    canparent = true,
+    caliber = 0.762,
+    weight = 15,
+    year = 1930,
+    magsize = 250,
+    magreload = 6,
+    round = {
+        maxlength = 13,
+        propweight = 0.04,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/mortar/120mmM.lua
+++ b/lua/cfc_acf_stubber/stubs/mortar/120mmM.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.64,
     name = "120mm Mortar",
     desc = "The versatile 120 is sometimes vehicle-mounted to provide quick boomsplat to support the infantry.  Carries more boom in its boomsplat, has good HEAT performance, and is more accurate in high-angle firing.",

--- a/lua/cfc_acf_stubber/stubs/mortar/120mmM.lua
+++ b/lua/cfc_acf_stubber/stubs/mortar/120mmM.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.64,
+    name = "120mm Mortar",
+    desc = "The versatile 120 is sometimes vehicle-mounted to provide quick boomsplat to support the infantry.  Carries more boom in its boomsplat, has good HEAT performance, and is more accurate in high-angle firing.",
+    muzzleflash = "40mm_muzzleflash_noscale",
+    rofmod = 2.5,
+    sound = "weapons/ACF_Gun/mortar_new.wav",
+    soundDistance = "Mortar.Fire",
+    soundNormal = " ",
+    model = "models/mortar/mortar_120mm.mdl",
+    gunclass = "MO",
+    caliber = 12.0,
+    weight = 640,
+    year = 1935,
+    round = {
+        maxlength = 45,
+        propweight = 0.175,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/mortar/150mmM.lua
+++ b/lua/cfc_acf_stubber/stubs/mortar/150mmM.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = false,
+    enabled = false,
     spread = 0.64,
     name = "150mm Mortar",
     desc = "The perfect balance between the 120mm and the 200mm. Can prove a worthy main gun weapon, as well as a mighty good mortar emplacement",

--- a/lua/cfc_acf_stubber/stubs/mortar/150mmM.lua
+++ b/lua/cfc_acf_stubber/stubs/mortar/150mmM.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = false,
+    spread = 0.64,
+    name = "150mm Mortar",
+    desc = "The perfect balance between the 120mm and the 200mm. Can prove a worthy main gun weapon, as well as a mighty good mortar emplacement",
+    muzzleflash = "40mm_muzzleflash_noscale",
+    rofmod = 2.5,
+    sound = "weapons/ACF_Gun/mortar_new.wav",
+    soundDistance = "Mortar.Fire",
+    soundNormal = " ",
+    model = "models/mortar/mortar_150mm.mdl",
+    gunclass = "MO",
+    caliber = 15.0,
+    weight = 1255,
+    year = 1945,
+    round = {
+        maxlength = 58,
+        propweight = 0.235,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/mortar/200mmM.lua
+++ b/lua/cfc_acf_stubber/stubs/mortar/200mmM.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = false,
+    spread = 0.64,
+    name = "200mm Mortar",
+    desc = "The 200mm is a beast, often used against fortifications.  Though enormously powerful, feel free to take a nap while it reloads",
+    muzzleflash = "40mm_muzzleflash_noscale",
+    rofmod = 2.5,
+    sound = "weapons/ACF_Gun/mortar_new.wav",
+    soundDistance = "Mortar.Fire",
+    soundNormal = " ",
+    model = "models/mortar/mortar_200mm.mdl",
+    gunclass = "MO",
+    caliber = 20.0,
+    weight = 2850,
+    year = 1940,
+    round = {
+        maxlength = 80,
+        propweight = 0.330,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/mortar/200mmM.lua
+++ b/lua/cfc_acf_stubber/stubs/mortar/200mmM.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = false,
+    enabled = false,
     spread = 0.64,
     name = "200mm Mortar",
     desc = "The 200mm is a beast, often used against fortifications.  Though enormously powerful, feel free to take a nap while it reloads",

--- a/lua/cfc_acf_stubber/stubs/mortar/60mmM.lua
+++ b/lua/cfc_acf_stubber/stubs/mortar/60mmM.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.64,
     name = "60mm Mortar",
     desc = "The 60mm is a common light infantry support weapon, with a high rate of fire but a puny payload.",

--- a/lua/cfc_acf_stubber/stubs/mortar/60mmM.lua
+++ b/lua/cfc_acf_stubber/stubs/mortar/60mmM.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.64,
+    name = "60mm Mortar",
+    desc = "The 60mm is a common light infantry support weapon, with a high rate of fire but a puny payload.",
+    muzzleflash = "40mm_muzzleflash_noscale",
+    rofmod = 1.25,
+    sound = "weapons/ACF_Gun/mortar_new.wav",
+    soundDistance = "Mortar.Fire",
+    soundNormal = " ",
+    model = "models/mortar/mortar_60mm.mdl",
+    gunclass = "MO",
+    caliber = 6.0,
+    weight = 60,
+    year = 1930,
+    round = {
+        maxlength = 20,
+        propweight = 0.037,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/mortar/80mmM.lua
+++ b/lua/cfc_acf_stubber/stubs/mortar/80mmM.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.64,
+    name = "80mm Mortar",
+    desc = "The 80mm is a common infantry support weapon, with a good bit more boom than its little cousin.",
+    muzzleflash = "40mm_muzzleflash_noscale",
+    rofmod = 2.5,
+    sound = "weapons/ACF_Gun/mortar_new.wav",
+    soundDistance = "Mortar.Fire",
+    soundNormal = " ",
+    model = "models/mortar/mortar_80mm.mdl",
+    gunclass = "MO",
+    caliber = 8.0,
+    weight = 120,
+    year = 1930,
+    round = {
+        maxlength = 28,
+        propweight = 0.055,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/mortar/80mmM.lua
+++ b/lua/cfc_acf_stubber/stubs/mortar/80mmM.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.64,
     name = "80mm Mortar",
     desc = "The 80mm is a common infantry support weapon, with a good bit more boom than its little cousin.",

--- a/lua/cfc_acf_stubber/stubs/rotary_autocannon/14.5mmRAC.lua
+++ b/lua/cfc_acf_stubber/stubs/rotary_autocannon/14.5mmRAC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.4,
     name = "14.5mm Rotary Autocannon",
     desc = "A lightweight rotary autocannon, used primarily against infantry and light vehicles.  It has a lower firerate than its larger brethren, but a significantly quicker cooldown period as well.",

--- a/lua/cfc_acf_stubber/stubs/rotary_autocannon/14.5mmRAC.lua
+++ b/lua/cfc_acf_stubber/stubs/rotary_autocannon/14.5mmRAC.lua
@@ -1,0 +1,25 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.4,
+    name = "14.5mm Rotary Autocannon",
+    desc = "A lightweight rotary autocannon, used primarily against infantry and light vehicles.  It has a lower firerate than its larger brethren, but a significantly quicker cooldown period as well.",
+    muzzleflash = "50cal_muzzleflash_noscale",
+    rofmod = 5.4,
+    sound = "weapons/acf_gun/mg_fire3.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    color = {135, 135, 135},
+    model = "models/rotarycannon/kw/14_5mmrac.mdl",
+    gunclass = "RAC",
+    caliber = 1.45,
+    weight = 240,
+    year = 1962,
+    magsize = 60,
+    magreload = 6,
+    round = {
+        maxlength = 25,
+        propweight = 0.06,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/rotary_autocannon/20mmHRAC.lua
+++ b/lua/cfc_acf_stubber/stubs/rotary_autocannon/20mmHRAC.lua
@@ -1,0 +1,25 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.4,
+    name = "20mm Heavy Rotary Autocannon",
+    desc = "A reinforced, heavy-duty 20mm rotary autocannon, able to fire heavier rounds with a larger magazine.  Phalanx.",
+    muzzleflash = "50cal_muzzleflash_noscale",
+    rofmod = 2.5,
+    sound = "weapons/acf_gun/mg_fire3.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    color = {135, 135, 135},
+    model = "models/rotarycannon/kw/20mmrac.mdl",
+    gunclass = "RAC",
+    caliber = 2.0,
+    weight = 1200,
+    year = 1981,
+    magsize = 60,
+    magreload = 4,
+    round = {
+        maxlength = 36,
+        propweight = 0.12,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/rotary_autocannon/20mmHRAC.lua
+++ b/lua/cfc_acf_stubber/stubs/rotary_autocannon/20mmHRAC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.4,
     name = "20mm Heavy Rotary Autocannon",
     desc = "A reinforced, heavy-duty 20mm rotary autocannon, able to fire heavier rounds with a larger magazine.  Phalanx.",

--- a/lua/cfc_acf_stubber/stubs/rotary_autocannon/20mmRAC.lua
+++ b/lua/cfc_acf_stubber/stubs/rotary_autocannon/20mmRAC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.4,
     name = "20mm Rotary Autocannon",
     desc = "The 20mm is able to chew up light armor with decent penetration or put up a big flak screen. Typically mounted on ground attack aircraft, SPAAGs and the ocassional APC. Suffers from a moderate cooldown period between bursts to avoid overheating the barrels.",

--- a/lua/cfc_acf_stubber/stubs/rotary_autocannon/20mmRAC.lua
+++ b/lua/cfc_acf_stubber/stubs/rotary_autocannon/20mmRAC.lua
@@ -1,0 +1,25 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.4,
+    name = "20mm Rotary Autocannon",
+    desc = "The 20mm is able to chew up light armor with decent penetration or put up a big flak screen. Typically mounted on ground attack aircraft, SPAAGs and the ocassional APC. Suffers from a moderate cooldown period between bursts to avoid overheating the barrels.",
+    muzzleflash = "50cal_muzzleflash_noscale",
+    rofmod = 2.1,
+    sound = "weapons/acf_gun/mg_fire3.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    color = {135, 135, 135},
+    model = "models/rotarycannon/kw/20mmrac.mdl",
+    gunclass = "RAC",
+    caliber = 2.0,
+    weight = 760,
+    year = 1965,
+    magsize = 40,
+    magreload = 7,
+    round = {
+        maxlength = 30,
+        propweight = 0.12,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/rotary_autocannon/30mmHRAC.lua
+++ b/lua/cfc_acf_stubber/stubs/rotary_autocannon/30mmHRAC.lua
@@ -1,0 +1,25 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.4,
+    name = "30mm Heavy Rotary Autocannon",
+    desc = "A reinforced, heavy duty 30mm rotary autocannon, able to fire heavier rounds with a larger magazine.  Keeper of goals.",
+    muzzleflash = "50cal_muzzleflash_noscale",
+    rofmod = 1.2,
+    sound = "weapons/acf_gun/mg_fire3.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    color = {135, 135, 135},
+    model = "models/rotarycannon/kw/30mmrac.mdl",
+    gunclass = "RAC",
+    caliber = 3.0,
+    weight = 2850,
+    year = 1985,
+    magsize = 50,
+    magreload = 6,
+    round = {
+        maxlength = 45,
+        propweight = 0.350,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/rotary_autocannon/30mmHRAC.lua
+++ b/lua/cfc_acf_stubber/stubs/rotary_autocannon/30mmHRAC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.4,
     name = "30mm Heavy Rotary Autocannon",
     desc = "A reinforced, heavy duty 30mm rotary autocannon, able to fire heavier rounds with a larger magazine.  Keeper of goals.",

--- a/lua/cfc_acf_stubber/stubs/rotary_autocannon/30mmRAC.lua
+++ b/lua/cfc_acf_stubber/stubs/rotary_autocannon/30mmRAC.lua
@@ -1,0 +1,25 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.4,
+    name = "30mm Rotary Autocannon",
+    desc = "The 30mm is the bane of ground-attack aircraft, able to tear up light armor without giving one single fuck.  Also seen in the skies above dead T-72s.  Has a moderate cooldown period between bursts to avoid overheating the barrels.",
+    muzzleflash = "50cal_muzzleflash_noscale",
+    rofmod = 1,
+    sound = "weapons/acf_gun/mg_fire3.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    color = {135, 135, 135},
+    model = "models/rotarycannon/kw/30mmrac.mdl",
+    gunclass = "RAC",
+    caliber = 3.0,
+    weight = 1500,
+    year = 1975,
+    magsize = 40,
+    magreload = 8,
+    round = {
+        maxlength = 40,
+        propweight = 0.350,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/rotary_autocannon/30mmRAC.lua
+++ b/lua/cfc_acf_stubber/stubs/rotary_autocannon/30mmRAC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.4,
     name = "30mm Rotary Autocannon",
     desc = "The 30mm is the bane of ground-attack aircraft, able to tear up light armor without giving one single fuck.  Also seen in the skies above dead T-72s.  Has a moderate cooldown period between bursts to avoid overheating the barrels.",

--- a/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/25mmSA.lua
+++ b/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/25mmSA.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.1,
+    name = "25mm Semiautomatic Cannon",
+    desc = "The 25mm semiauto can quickly put five rounds downrange, being lethal, yet light.",
+    muzzleflash = "30mm_muzzleflash_noscale",
+    rofmod = 0.7,
+    sound = "acf_extra/tankfx/gnomefather/25mm1.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    model = "models/autocannon/semiautocannon_25mm.mdl",
+    gunclass = "SA",
+    caliber = 2.5,
+    weight = 200,
+    year = 1935,
+    magsize = 5,
+    magreload = 2,
+    round = {
+        maxlength = 39,
+        propweight = 0.5,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/25mmSA.lua
+++ b/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/25mmSA.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.1,
     name = "25mm Semiautomatic Cannon",
     desc = "The 25mm semiauto can quickly put five rounds downrange, being lethal, yet light.",

--- a/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/37mmSA.lua
+++ b/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/37mmSA.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.1,
+    name = "37mm Semiautomatic Cannon",
+    desc = "The 37mm is surprisingly powerful, its five-round clips boasting a respectable payload and a high muzzle velocity.",
+    muzzleflash = "30mm_muzzleflash_noscale",
+    rofmod = 0.7,
+    sound = "acf_extra/tankfx/gnomefather/25mm1.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    model = "models/autocannon/semiautocannon_37mm.mdl",
+    gunclass = "SA",
+    caliber = 3.7,
+    weight = 540,
+    year = 1940,
+    magsize = 5,
+    magreload = 3.5,
+    round = {
+        maxlength = 42,
+        propweight = 1.125,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/37mmSA.lua
+++ b/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/37mmSA.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.1,
     name = "37mm Semiautomatic Cannon",
     desc = "The 37mm is surprisingly powerful, its five-round clips boasting a respectable payload and a high muzzle velocity.",

--- a/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/45mmSA.lua
+++ b/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/45mmSA.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.1,
+    name = "45mm Semiautomatic Cannon",
+    desc = "The 45mm can easily shred light armor, with a respectable rate of fire, but its armor penetration pales in comparison to regular cannons.",
+    muzzleflash = "30mm_muzzleflash_noscale",
+    rofmod = 0.72,
+    sound = "acf_extra/tankfx/gnomefather/25mm1.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    model = "models/autocannon/semiautocannon_45mm.mdl",
+    gunclass = "SA",
+    caliber = 4.5,
+    weight = 870,
+    year = 1965,
+    magsize = 5,
+    magreload = 4,
+    round = {
+        maxlength = 52,
+        propweight = 1.8,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/45mmSA.lua
+++ b/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/45mmSA.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.1,
     name = "45mm Semiautomatic Cannon",
     desc = "The 45mm can easily shred light armor, with a respectable rate of fire, but its armor penetration pales in comparison to regular cannons.",

--- a/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/57mmSA.lua
+++ b/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/57mmSA.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.1,
+    name = "57mm Semiautomatic Cannon",
+    desc = "The 57mm is a respectable light armament, offering considerable penetration and moderate fire rate.",
+    muzzleflash = "30mm_muzzleflash_noscale",
+    rofmod = 0.8,
+    sound = "acf_extra/tankfx/gnomefather/25mm1.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    model = "models/autocannon/semiautocannon_57mm.mdl",
+    gunclass = "SA",
+    caliber = 5.7,
+    weight = 1560,
+    year = 1965,
+    magsize = 5,
+    magreload = 4.5,
+    round = {
+        maxlength = 62,
+        propweight = 2,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/57mmSA.lua
+++ b/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/57mmSA.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.1,
     name = "57mm Semiautomatic Cannon",
     desc = "The 57mm is a respectable light armament, offering considerable penetration and moderate fire rate.",

--- a/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/76mmSA.lua
+++ b/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/76mmSA.lua
@@ -1,0 +1,24 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.1,
+    name = "76mm Semiautomatic Cannon",
+    desc = "The 76mm semiauto is a fearsome weapon, able to put 5 76mm rounds downrange in 8 seconds.",
+    muzzleflash = "30mm_muzzleflash_noscale",
+    rofmod = 0.85,
+    sound = "acf_extra/tankfx/gnomefather/25mm1.wav",
+    soundDistance = " ",
+    soundNormal = " ",
+    model = "models/autocannon/semiautocannon_76mm.mdl",
+    gunclass = "SA",
+    caliber = 7.62,
+    weight = 2990,
+    year = 1984,
+    magsize = 5,
+    magreload = 5,
+    round = {
+        maxlength = 70,
+        propweight = 4.75,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/76mmSA.lua
+++ b/lua/cfc_acf_stubber/stubs/semiautomatic_cannon/76mmSA.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.1,
     name = "76mm Semiautomatic Cannon",
     desc = "The 76mm semiauto is a fearsome weapon, able to put 5 76mm rounds downrange in 8 seconds.",

--- a/lua/cfc_acf_stubber/stubs/short-barrel_cannon/100mmSC.lua
+++ b/lua/cfc_acf_stubber/stubs/short-barrel_cannon/100mmSC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.2,
     name = "100mm Short Cannon",
     desc = "The 100mm is an effective infantry-support or antitank weapon, with a lot of uses and surprising lethality.",

--- a/lua/cfc_acf_stubber/stubs/short-barrel_cannon/100mmSC.lua
+++ b/lua/cfc_acf_stubber/stubs/short-barrel_cannon/100mmSC.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.2,
+    name = "100mm Short Cannon",
+    desc = "The 100mm is an effective infantry-support or antitank weapon, with a lot of uses and surprising lethality.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.7,
+    sound = "weapons/ACF_Gun/cannon_new.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_short_100mm.mdl",
+    gunclass = "SC",
+    caliber = 10.0,
+    weight = 1750,
+    year = 1940,
+    round = {
+        maxlength = 93,
+        propweight = 4.5,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/short-barrel_cannon/120mmSC.lua
+++ b/lua/cfc_acf_stubber/stubs/short-barrel_cannon/120mmSC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.2,
     name = "120mm Short Cannon",
     desc = "The 120mm is a formidable yet lightweight weapon, with excellent performance against larger vehicles.",

--- a/lua/cfc_acf_stubber/stubs/short-barrel_cannon/120mmSC.lua
+++ b/lua/cfc_acf_stubber/stubs/short-barrel_cannon/120mmSC.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.2,
+    name = "120mm Short Cannon",
+    desc = "The 120mm is a formidable yet lightweight weapon, with excellent performance against larger vehicles.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.7,
+    sound = "weapons/ACF_Gun/cannon_new.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_short_120mm.mdl",
+    gunclass = "SC",
+    caliber = 12.0,
+    weight = 3800,
+    year = 1944,
+    round = {
+        maxlength = 110,
+        propweight = 8.5,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/short-barrel_cannon/140mmSC.lua
+++ b/lua/cfc_acf_stubber/stubs/short-barrel_cannon/140mmSC.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.2,
+    name = "140mm Short Cannon",
+    desc = "A specialized weapon, developed from dark magic and anti-heavy tank hatred.  Deal with it.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.7,
+    sound = "weapons/ACF_Gun/cannon_new.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_short_140mm.mdl",
+    gunclass = "SC",
+    caliber = 14.0,
+    weight = 6040,
+    year = 1999,
+    round = {
+        maxlength = 127,
+        propweight = 12.8,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/short-barrel_cannon/140mmSC.lua
+++ b/lua/cfc_acf_stubber/stubs/short-barrel_cannon/140mmSC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.2,
     name = "140mm Short Cannon",
     desc = "A specialized weapon, developed from dark magic and anti-heavy tank hatred.  Deal with it.",

--- a/lua/cfc_acf_stubber/stubs/short-barrel_cannon/37mmSC.lua
+++ b/lua/cfc_acf_stubber/stubs/short-barrel_cannon/37mmSC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.2,
     name = "37mm Short Cannon",
     desc = "Quick-firing and light, but penetration is laughable.  You're better off throwing rocks.",

--- a/lua/cfc_acf_stubber/stubs/short-barrel_cannon/37mmSC.lua
+++ b/lua/cfc_acf_stubber/stubs/short-barrel_cannon/37mmSC.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.2,
+    name = "37mm Short Cannon",
+    desc = "Quick-firing and light, but penetration is laughable.  You're better off throwing rocks.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.4,
+    sound = "weapons/ACF_Gun/ac_fire4.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_short_37mm.mdl",
+    gunclass = "SC",
+    caliber = 3.7,
+    weight = 200,
+    year = 1915,
+    round = {
+        maxlength = 45,
+        propweight = 0.29,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/short-barrel_cannon/50mmSC.lua
+++ b/lua/cfc_acf_stubber/stubs/short-barrel_cannon/50mmSC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.2,
     name = "50mm Short Cannon",
     desc = "The 50mm is a quick-firing pea-shooter, good for scouts, and common on old interwar tanks.",

--- a/lua/cfc_acf_stubber/stubs/short-barrel_cannon/50mmSC.lua
+++ b/lua/cfc_acf_stubber/stubs/short-barrel_cannon/50mmSC.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.2,
+    name = "50mm Short Cannon",
+    desc = "The 50mm is a quick-firing pea-shooter, good for scouts, and common on old interwar tanks.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.4,
+    sound = "weapons/ACF_Gun/ac_fire4.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_short_50mm.mdl",
+    gunclass = "SC",
+    caliber = 5.0,
+    weight = 330,
+    year = 1915,
+    round = {
+        maxlength = 63,
+        propweight = 0.6,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/short-barrel_cannon/75mmSC.lua
+++ b/lua/cfc_acf_stubber/stubs/short-barrel_cannon/75mmSC.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.2,
+    name = "75mm Short Cannon",
+    desc = "The 75mm is common WW2 medium tank armament, and still useful in many other applications.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.7,
+    sound = "weapons/ACF_Gun/cannon_new.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun/tankgun_short_75mm.mdl",
+    gunclass = "SC",
+    caliber = 7.5,
+    weight = 750,
+    year = 1936,
+    round = {
+        maxlength = 76,
+        propweight = 2,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/short-barrel_cannon/75mmSC.lua
+++ b/lua/cfc_acf_stubber/stubs/short-barrel_cannon/75mmSC.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.2,
     name = "75mm Short Cannon",
     desc = "The 75mm is common WW2 medium tank armament, and still useful in many other applications.",

--- a/lua/cfc_acf_stubber/stubs/smoke_launcher/40mmCL.lua
+++ b/lua/cfc_acf_stubber/stubs/smoke_launcher/40mmCL.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.32,
     name = "40mm Countermeasure Launcher",
     desc = "A revolver-style launcher capable of firing off several smoke or flare rounds.",

--- a/lua/cfc_acf_stubber/stubs/smoke_launcher/40mmCL.lua
+++ b/lua/cfc_acf_stubber/stubs/smoke_launcher/40mmCL.lua
@@ -1,0 +1,25 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.32,
+    name = "40mm Countermeasure Launcher",
+    desc = "A revolver-style launcher capable of firing off several smoke or flare rounds.",
+    muzzleflash = "40mm_muzzleflash_noscale",
+    rofmod = 0.015,
+    sound = "weapons/acf_gun/smoke_launch.wav",
+    soundDistance = "Mortar.Fire",
+    soundNormal = " ",
+    model = "models/launcher/40mmgl.mdl",
+    gunclass = "SL",
+    canparent = true,
+    caliber = 4.0,
+    weight = 20,
+    magsize = 6,
+    magreload = 40,
+    year = 1950,
+    round = {
+        maxlength = 12,
+        propweight = 0.001,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/smoke_launcher/40mmSL.lua
+++ b/lua/cfc_acf_stubber/stubs/smoke_launcher/40mmSL.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.32,
     name = "40mm Smoke Launcher",
     desc = "",

--- a/lua/cfc_acf_stubber/stubs/smoke_launcher/40mmSL.lua
+++ b/lua/cfc_acf_stubber/stubs/smoke_launcher/40mmSL.lua
@@ -1,0 +1,23 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.32,
+    name = "40mm Smoke Launcher",
+    desc = "",
+    muzzleflash = "40mm_muzzleflash_noscale",
+    rofmod = 45,
+    sound = "weapons/acf_gun/smoke_launch.wav",
+    soundDistance = "Mortar.Fire",
+    soundNormal = " ",
+    model = "models/launcher/40mmsl.mdl",
+    gunclass = "SL",
+    canparent = true,
+    caliber = 4.0,
+    weight = 1,
+    year = 1941,
+    round = {
+        maxlength = 17.5,
+        propweight = 0.000075,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/smoothbore_cannon/105mmSB.lua
+++ b/lua/cfc_acf_stubber/stubs/smoothbore_cannon/105mmSB.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.08,
+    name = "105mm Smoothbore Cannon",
+    desc = "The 105mm was a benchmark for the early cold war period, and has great muzzle velocity and hitting power, while still boasting a respectable, if small, payload.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.72,
+    sound = "weapons/ACF_Gun/cannon_new.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun_old/tankgun_100mm.mdl",
+    gunclass = "SB",
+    caliber = 10.5,
+    weight = 3550,
+    year = 1970,
+    round = {
+        maxlength = 93+8,
+        propweight = 9,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/smoothbore_cannon/105mmSB.lua
+++ b/lua/cfc_acf_stubber/stubs/smoothbore_cannon/105mmSB.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.08,
     name = "105mm Smoothbore Cannon",
     desc = "The 105mm was a benchmark for the early cold war period, and has great muzzle velocity and hitting power, while still boasting a respectable, if small, payload.",

--- a/lua/cfc_acf_stubber/stubs/smoothbore_cannon/120mmSB.lua
+++ b/lua/cfc_acf_stubber/stubs/smoothbore_cannon/120mmSB.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = true,
+    spread = 0.08,
+    name = "120mm Smoothbore Cannon",
+    desc = "Often found in MBTs, the 120mm shreds lighter armor with utter impunity, and is formidable against even the big boys.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.72,
+    sound = "weapons/ACF_Gun/cannon_new.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun_old/tankgun_120mm.mdl",
+    gunclass = "SB",
+    caliber = 12.0,
+    weight = 6000,
+    year = 1975,
+    round = {
+        maxlength = 110+13,
+        propweight = 18,
+    },
+}

--- a/lua/cfc_acf_stubber/stubs/smoothbore_cannon/120mmSB.lua
+++ b/lua/cfc_acf_stubber/stubs/smoothbore_cannon/120mmSB.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = true,
+    enabled = true,
     spread = 0.08,
     name = "120mm Smoothbore Cannon",
     desc = "Often found in MBTs, the 120mm shreds lighter armor with utter impunity, and is formidable against even the big boys.",

--- a/lua/cfc_acf_stubber/stubs/smoothbore_cannon/140mmSB.lua
+++ b/lua/cfc_acf_stubber/stubs/smoothbore_cannon/140mmSB.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 DATA = {
-	enabled = false,
+    enabled = false,
     spread = 0.08,
     name = "140mm Smoothbore Cannonn",
     desc = "The 140mm fires a massive shell with enormous penetrative capability, but has a glacial reload speed and a very hefty weight.",

--- a/lua/cfc_acf_stubber/stubs/smoothbore_cannon/140mmSB.lua
+++ b/lua/cfc_acf_stubber/stubs/smoothbore_cannon/140mmSB.lua
@@ -1,0 +1,22 @@
+AddCSLuaFile()
+
+DATA = {
+	enabled = false,
+    spread = 0.08,
+    name = "140mm Smoothbore Cannonn",
+    desc = "The 140mm fires a massive shell with enormous penetrative capability, but has a glacial reload speed and a very hefty weight.",
+    muzzleflash = "120mm_muzzleflash_noscale",
+    rofmod = 1.72,
+    sound = "weapons/ACF_Gun/cannon_new.wav",
+    soundDistance = "Cannon.Fire",
+    soundNormal = " ",
+    model = "models/tankgun_old/tankgun_140mm.mdl",
+    gunclass = "SB",
+    caliber = 14.0,
+    weight = 8980,
+    year = 1990,
+    round = {
+        maxlength = 127+18,
+        propweight = 28,
+    },
+}


### PR DESCRIPTION
Each ACF gun has a stub, the stub simply includes itself and defines `DATA` for that gun.
The first field in all weapon's `DATA` is `enabled`, set this to false to disable the weapon.
Example stub [here](https://github.com/CFC-Servers/cfc_acf_stubber/blob/initial/lua/cfc_acf_stubber/stubs/autocannon/20mmAC.lua)
Python script included [here](https://github.com/CFC-Servers/cfc_acf_stubber/blob/initial/lib/config_generator.py) for generating stubs with default data.